### PR TITLE
fix: add `Type` to `SystemSpec`

### DIFF
--- a/catalog/spec_system.go
+++ b/catalog/spec_system.go
@@ -8,4 +8,6 @@ type SystemSpec struct {
 	Owner string `json:"owner"`
 	// An entity reference to the domain that the system belongs to.
 	Domain string `json:"domain,omitempty"`
+	// The type of system. There is currently no enforced set of values for this field, so it is left up to the adopting organization to choose a nomenclature that matches their catalog hierarchy. This field is optional.
+	Type string `json:"type,omitempty"`
 }

--- a/catalog/spec_system.go
+++ b/catalog/spec_system.go
@@ -8,6 +8,8 @@ type SystemSpec struct {
 	Owner string `json:"owner"`
 	// An entity reference to the domain that the system belongs to.
 	Domain string `json:"domain,omitempty"`
-	// The type of system. There is currently no enforced set of values for this field, so it is left up to the adopting organization to choose a nomenclature that matches their catalog hierarchy. This field is optional.
+	// The type of system. There is currently no enforced set of values for this field,
+	// so it is left up to the adopting organization to choose a nomenclature that matches
+	// their catalog hierarchy. This field is optional.
 	Type string `json:"type,omitempty"`
 }

--- a/catalog/spec_system_test.go
+++ b/catalog/spec_system_test.go
@@ -9,12 +9,13 @@ import (
 
 func TestEntity_SystemSpec(t *testing.T) {
 	//nolint: lll
-	const system = `{"apiVersion":"backstage.io/v1alpha1","kind":"System","metadata":{"name":"podcast","description":"Podcast playback"},"spec":{"owner":"team-b","domain":"playback"}}`
+	const system = `{"apiVersion":"backstage.io/v1alpha1","kind":"System","metadata":{"name":"podcast","description":"Podcast playback"},"spec":{"owner":"team-b","domain":"playback", "type":"product"}}`
 	var entity Entity
 	assert.NilError(t, json.Unmarshal([]byte(system), &entity))
 	expected := &SystemSpec{
 		Owner:  "team-b",
 		Domain: "playback",
+		Type:   "product",
 	}
 	actual, err := entity.SystemSpec()
 	assert.NilError(t, err)


### PR DESCRIPTION
I noticed `SystemSpec` was missing the [optional field `Type`](https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-optional), and I need it on a project I'm working on, so I just went ahead and added it.