### PR TITLE
feat(catalog): add entities/by-query endpoint

### DIFF
--- a/catalog/client_entities_query.go
+++ b/catalog/client_entities_query.go
@@ -1,0 +1,78 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// QueryEntitiesRequest is the request to the [Client.QueryEntities] method.
+type QueryEntitiesRequest struct {
+	// Filters for selecting only a subset of all entities.
+	// Multiple filter sets with AND/OR conditions are supported.
+	Filters []string
+	// Fields for selecting only parts of the full data structure of each entity.
+	Fields []string
+	// Limit for the number of returned entities (default 20).
+	Limit int64
+	// OrderField for customizing entity sorting.
+	// Format: "field,direction" where direction is "asc" or "desc".
+	OrderField string
+	// Cursor for cursor-based pagination.
+	// Mutually exclusive with other query parameters.
+	Cursor string
+}
+
+// PageInfo contains pagination information for cursor-based pagination.
+type PageInfo struct {
+	// NextCursor contains the cursor for the next page.
+	NextCursor string `json:"nextCursor,omitempty"`
+	// PrevCursor contains the cursor for the previous page.
+	PrevCursor string `json:"prevCursor,omitempty"`
+}
+
+// QueryEntitiesResponse is the response from the [Client.QueryEntities] method.
+type QueryEntitiesResponse struct {
+	// Items contains the entities in the response.
+	Entities []*Entity `json:"items"`
+	// PageInfo contains pagination information.
+	PageInfo *PageInfo `json:"pageInfo,omitempty"`
+}
+
+// QueryEntities queries entities in the catalog using the more efficient by-query endpoint.
+//
+// This method supports cursor-based pagination, flexible querying options, and customizable sorting.
+// It provides better performance compared to the traditional ListEntities method.
+//
+// See: https://backstage.io/docs/features/software-catalog/software-catalog-api/#get-entities
+func (c *Client) QueryEntities(ctx context.Context, request *QueryEntitiesRequest) (*QueryEntitiesResponse, error) {
+	const path = "/api/catalog/entities/by-query"
+	query := make(url.Values)
+
+	if request.Limit > 0 {
+		query.Set("limit", strconv.FormatInt(request.Limit, 10))
+	}
+	for _, filter := range request.Filters {
+		query.Add("filter", filter)
+	}
+	if len(request.Fields) > 0 {
+		query.Set("fields", strings.Join(request.Fields, ","))
+	}
+	if request.OrderField != "" {
+		query.Set("orderField", request.OrderField)
+	}
+	if request.Cursor != "" {
+		query.Set("cursor", request.Cursor)
+	}
+	var response QueryEntitiesResponse
+	if err := c.get(ctx, path, query, func(httpResponse *http.Response) error {
+		return json.NewDecoder(httpResponse.Body).Decode(&response)
+	}); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/catalog/client_entities_query_test.go
+++ b/catalog/client_entities_query_test.go
@@ -1,0 +1,175 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestClient_QueryEntities(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		const (
+			system1 = `{"apiVersion":"backstage.io/v1alpha1","kind":"System","metadata":{"name":"system1"}}`
+			system2 = `{"apiVersion":"backstage.io/v1alpha1","kind":"System","metadata":{"name":"system2"}}`
+		)
+		expectedEntities := []*Entity{
+			{
+				APIVersion: "backstage.io/v1alpha1",
+				Kind:       EntityKindSystem,
+				Metadata: EntityMetadata{
+					Name: "system1",
+				},
+				Raw: json.RawMessage(system1),
+			},
+			{
+				APIVersion: "backstage.io/v1alpha1",
+				Kind:       EntityKindSystem,
+				Metadata: EntityMetadata{
+					Name: "system2",
+				},
+				Raw: json.RawMessage(system2),
+			},
+		}
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/catalog/entities/by-query", r.URL.Path)
+			assert.Equal(t, "kind=Component", r.URL.Query().Get("filter"))
+			assert.Equal(t, "metadata.name,asc", r.URL.Query().Get("orderField"))
+			assert.Equal(t, "100", r.URL.Query().Get("limit"))
+			assert.Equal(t, "", r.URL.Query().Get("cursor"))
+			assert.Equal(t, "metadata.name,spec.type", r.URL.Query().Get("fields"))
+
+			response := fmt.Sprintf(`{
+				"items": [%s,%s],
+				"totalItems": 2,
+				"pageInfo": {
+					"nextCursor": "nextCursor123",
+					"prevCursor": "prevCursor456"
+				}
+			}`, system1, system2)
+			_, _ = w.Write([]byte(response))
+		})
+		actual, err := client.QueryEntities(ctx, &QueryEntitiesRequest{
+			Filters:    []string{"kind=Component"},
+			Fields:     []string{"metadata.name", "spec.type"},
+			Limit:      100,
+			OrderField: "metadata.name,asc",
+			Cursor:     "",
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, expectedEntities, actual.Entities)
+		assert.Equal(t, int64(2), int64(len(actual.Entities)))
+		assert.Equal(t, "nextCursor123", actual.PageInfo.NextCursor)
+		assert.Equal(t, "prevCursor456", actual.PageInfo.PrevCursor)
+	})
+
+	t.Run("success with multiple filters", func(t *testing.T) {
+		const system1 = `{"apiVersion":"backstage.io/v1alpha1","kind":"System","metadata":{"name":"system1"}}`
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/catalog/entities/by-query", r.URL.Path)
+			filters := r.URL.Query()["filter"]
+			assert.Equal(t, 2, len(filters))
+			assert.Assert(t, contains(filters, "kind=Component"))
+			assert.Assert(t, contains(filters, "spec.type=service"))
+
+			response := fmt.Sprintf(`{
+				"items": [%s],
+				"totalItems": 1,
+				"pageInfo": {
+					"nextCursor": "next"
+				}
+			}`, system1)
+			_, _ = w.Write([]byte(response))
+		})
+		actual, err := client.QueryEntities(ctx, &QueryEntitiesRequest{
+			Filters: []string{"kind=Component", "spec.type=service"},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(actual.Entities))
+		assert.Equal(t, int64(1), int64(len(actual.Entities)))
+		assert.Equal(t, "next", actual.PageInfo.NextCursor)
+	})
+
+	t.Run("success with minimal request", func(t *testing.T) {
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/catalog/entities/by-query", r.URL.Path)
+			assert.Equal(t, "", r.URL.Query().Get("limit"))
+			assert.Equal(t, "", r.URL.Query().Get("cursor"))
+			assert.Equal(t, "", r.URL.Query().Get("orderField"))
+			assert.Equal(t, "", r.URL.Query().Get("fields"))
+			assert.Equal(t, 0, len(r.URL.Query()["filter"]))
+
+			_, _ = w.Write([]byte(`{
+				"items": [],
+				"totalItems": 0
+			}`))
+		})
+		actual, err := client.QueryEntities(ctx, &QueryEntitiesRequest{})
+		assert.NilError(t, err)
+		assert.Equal(t, 0, len(actual.Entities))
+		assert.Equal(t, int64(0), int64(len(actual.Entities)))
+		assert.Assert(t, actual.PageInfo == nil)
+	})
+
+	t.Run("success without pageInfo", func(t *testing.T) {
+		const system1 = `{"apiVersion":"backstage.io/v1alpha1","kind":"System","metadata":{"name":"system1"}}`
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/catalog/entities/by-query", r.URL.Path)
+
+			response := fmt.Sprintf(`{
+				"items": [%s],
+				"totalItems": 1
+			}`, system1)
+			_, _ = w.Write([]byte(response))
+		})
+		actual, err := client.QueryEntities(ctx, &QueryEntitiesRequest{})
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(actual.Entities))
+		assert.Equal(t, int64(1), int64(len(actual.Entities)))
+		assert.Assert(t, actual.PageInfo == nil)
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		const statusCode = http.StatusInternalServerError
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/catalog/entities/by-query", r.URL.Path)
+			w.WriteHeader(statusCode)
+		})
+		response, err := client.QueryEntities(ctx, &QueryEntitiesRequest{})
+		assert.Assert(t, response == nil)
+		var errStatus *StatusError
+		assert.Assert(t, errors.As(err, &errStatus))
+		assert.Equal(t, statusCode, errStatus.StatusCode)
+	})
+
+	t.Run("invalid json response", func(t *testing.T) {
+		client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/api/catalog/entities/by-query", r.URL.Path)
+			_, _ = w.Write([]byte(`invalid json`))
+		})
+		response, err := client.QueryEntities(ctx, &QueryEntitiesRequest{})
+		assert.Assert(t, response == nil)
+		assert.Assert(t, err != nil)
+	})
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Hello 👋 
Im opening this PR because the original `ListEntities` method that this SDK provides points to a [deprecated endpoint](https://backstage.io/docs/features/software-catalog/software-catalog-api/#get-entities). I added a new QueryEntities method that targets `/api/catalog/entities/by-query`, which supports also ordering and cursor-based pagination.